### PR TITLE
Add local-friendly tests and CI steps

### DIFF
--- a/docker/pip-requirements.txt
+++ b/docker/pip-requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 pydantic
 pytest
 requests
+httpx<0.26

--- a/python/setup.py
+++ b/python/setup.py
@@ -11,6 +11,7 @@ setup(
         "uvicorn[standard]",
         "pytest",
         "requests",
+        "httpx<0.26",
     ],
     python_requires=">=3.8",
     entry_points={

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest configuration for local runs without installing the package."""
+
+import os
+import sys
+
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1,0 +1,7 @@
+from mlc_llm import cli
+
+
+def test_cli_default_output(capsys):
+    cli.main()
+    captured = capsys.readouterr()
+    assert "MLC LLM CLI works!" in captured.out

--- a/python/tests/test_server.py
+++ b/python/tests/test_server.py
@@ -1,0 +1,24 @@
+import pytest
+
+try:
+    from fastapi.testclient import TestClient
+except Exception:  # pragma: no cover - optional dependency
+    pytest.skip("fastapi TestClient dependencies missing", allow_module_level=True)
+
+from mlc_llm.server import app
+
+client = TestClient(app)
+
+def test_root_endpoint():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "MLC-LLM server running"}
+
+def test_chat_endpoint():
+    payload = {"model": "test", "messages": [{"role": "user", "content": "Hi"}]}
+    response = client.post("/v1/chat/completions", json=payload)
+    assert response.status_code == 200
+    body = response.json()
+    assert body.get("model") == "test"
+    assert body["choices"][0]["message"]["role"] == "assistant"
+    assert "test model response" in body["choices"][0]["message"]["content"]

--- a/scripts/test-image.sh
+++ b/scripts/test-image.sh
@@ -2,14 +2,29 @@
 set -euo pipefail
 
 #
-# 1) Start FastAPI in background
+# 1) Basic import test
 #
-echo "[INFO] Starting FastAPI server in background..."
+echo "[1/3] Testing MLC-LLM Python import..."
+python - <<'EOF'
+import mlc_llm
+print("MLC-LLM imported successfully")
+EOF
+
+#
+# 2) Unit tests
+#
+echo "[2/3] Running pytest unit tests..."
+pytest python/tests
+
+#
+# 3) Start FastAPI in background
+#
+echo "[3/3] Starting FastAPI server in background..."
 mlc_llm serve --host 0.0.0.0 --port 8000 &
 SERVER_PID=$!
 
 #
-# 2) Poll until the server’s root (GET /) is healthy
+# Poll until the server’s root (GET /) is healthy
 #
 MAX_RETRIES=15
 SLEEP_SECONDS=3
@@ -34,7 +49,7 @@ if [[ $SUCCESS -ne 1 ]]; then
 fi
 
 #
-# 3) POST a dummy chat request, expect HTTP 200
+# POST a dummy chat request, expect HTTP 200
 #
 echo "[INFO] Running API test (POST /v1/chat/completions)..."
 set +e
@@ -68,7 +83,7 @@ echo "[INFO] Chat endpoint returned 200 OK. Dumping response body:"
 head -n -1 /tmp/chat_response.json || true
 
 #
-# 4) Tear down
+# Tear down
 #
 echo "[INFO] Stopping server..."
 kill "$SERVER_PID" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- ensure pytest can import package without installation
- conditionally skip server tests when `httpx` isn't available
- include `httpx<0.26` in package and Docker requirements
- run pytest inside `test-image.sh`

## Testing
- `pip install -e ./python`
- `pytest -q python/tests`


------
https://chatgpt.com/codex/tasks/task_e_6844772528888321960387c3d9bbd65d