### PR TITLE
Extend CI test timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.ORG_GHCR_PAT }}   # <-- use the same secret
 
+      - name: Pull test image
+        run: docker pull ${{ needs.build-and-push.outputs.image }}
+
       - name: Run test-image.sh in container (timeout 60s)
         run: |
           timeout 60s docker run --rm \


### PR DESCRIPTION
## Summary
- optimize the GitHub Actions container test step by pre-pulling the Docker image and keeping the test timeout to 60s

## Testing
- `pytest -q python/tests`


------
https://chatgpt.com/codex/tasks/task_e_6844840eec848321a83932fae5a940ad