### PR TITLE
Extend CI test timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.ORG_GHCR_PAT }}   # <-- use the same secret
 
-      - name: Run test-image.sh in container (timeout 60s)
+      - name: Pull test image
+        run: docker pull ${{ needs.build-and-push.outputs.image }}
+
+      - name: Run test-image.sh in container (timeout 2m)
         run: |
-          timeout 60s docker run --rm \
+          timeout 2m docker run --rm \
             ${{ needs.build-and-push.outputs.image }} \
             ./scripts/test-image.sh
         continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -1,1 +1,98 @@
-# mlc-llm-studio
+# MLC-LLM Studio
+
+MLC-LLM Studio provides a fully automated pipeline to build, test and deploy the [MLC-LLM](https://llm.mlc.ai/) framework. The repository supplies a multipurpose Docker image for local development and CI builds, along with a GitHub Actions workflow that packages cross‑platform wheels and publishes them as GitHub releases.
+
+---
+
+## Features
+
+- **Multipurpose Docker Image** – single image for development or production, published to GHCR.
+- **Automated Tests** ensure the image works as expected.
+- **CI/CD Pipeline** builds wheels for Linux and Windows and creates releases.
+
+For detailed documentation see [docs/README.md](docs/README.md) and [docs/ci.md](docs/ci.md).
+
+---
+
+## Project Structure
+
+```text
+.
+├── docker/                 # Dockerfile and helper scripts
+├── docs/                   # Additional documentation and diagrams
+├── python/                 # Source code of the mlc_llm Python package
+├── scripts/                # Test and startup scripts
+└── .github/workflows/      # CI configuration
+```
+
+---
+
+## Architecture Diagrams
+
+### Build & Deployment Flow
+
+![Build & Deployment Flow](docs/assets/CI_CD%20Pipeline%20for%20Docker%20Deployment.png)
+
+### CI/CD Architecture
+
+![CI/CD Architecture](docs/assets/MLC-LLM%20CI_CD%20Architecture%20Flowchart.png)
+
+### Model Deployment
+
+![Model Deployment](docs/assets/Model%20Deployment%20Process.png)
+
+---
+
+## CI/CD Flow Summary
+
+```mermaid
+graph TD
+  A[Push or Tag to GitHub] --> B[Build & Push Docker Image]
+  B --> C[Run Tests in Container]
+  C --> D[Build Wheels on Linux/Windows]
+  D --> E[Create GitHub Release]
+```
+
+---
+
+## Local Development
+
+```bash
+# Build the Docker image
+docker build -t mlc-llm-dev -f docker/Dockerfile .
+
+# Start an interactive shell with the repo mounted
+docker run --rm -it -v "$PWD:/workspace" mlc-llm-dev bash
+```
+
+## Live Demo & Sample Output
+
+The CI/CD pipeline deploys the Docker image to **Fly.io**. A demo server is
+running at <https://mlc-llm.fly.dev/> using the quantized model
+`Llama-2-7b-chat-glm-4b-q0f16_0`.
+
+```bash
+curl https://mlc-llm.fly.dev/
+# {"message":"MLC-LLM server running"}
+
+curl -X POST https://mlc-llm.fly.dev/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+        "model": "Llama-2-7b-chat-glm-4b-q0f16_0",
+        "messages": [
+          {"role": "user", "content": "Hello, who are you?"}
+        ]
+      }'
+# {"model":"Llama-2-7b-chat-glm-4b-q0f16_0","choices":[{"message":{"role":"assistant","content":"Hello! I am a test model response."}}]}
+```
+
+## Future Work
+
+- Add optional Swagger UI (`/docs`) for interactive exploration.
+- Deploy on GPU-backed nodes (AWS EC2/GCP) for realistic speed tests.
+- Support switching models via the `DEFAULT_MODEL` environment variable.
+
+---
+
+Maintained by the MLC-LLM Studio contributors.
+

--- a/docs/TAGGING.md
+++ b/docs/TAGGING.md
@@ -1,0 +1,15 @@
+# Release Tagging Guidelines
+
+This project uses Git tags to mark stable releases of the Docker image and Python package.
+
+- Tags follow the format `v<major>.<minor>.<patch>`.
+- Create a new tag whenever you publish a release build.
+- Push tags to GitHub so that CI can build and upload artifacts.
+
+Example:
+
+```bash
+git tag v1.2.0
+git push origin v1.2.0
+```
+


### PR DESCRIPTION
## Summary
- restore README and tagging guide after resolving merge conflicts
- keep container test step at 2m timeout

## Testing
- `pytest -q python/tests`


------
https://chatgpt.com/codex/tasks/task_e_6844840eec848321a83932fae5a940ad