### PR TITLE
Add configurable model info endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ To use a different model, set a `DEFAULT_MODEL` environment variable (or edit
 `fly.toml`) and ensure `docker/entrypoint.sh` reads this value as shown in
 [docs/ci.md](docs/ci.md#5-replacing-models).
 
+The currently deployed model can be verified by querying the `/info` endpoint:
+
+```bash
+curl https://mlc-llm.fly.dev/info
+# {"default_model":"Llama-2-7b-chat-glm-4b-q0f16_0"}
+```
+
 ```bash
 curl https://mlc-llm.fly.dev/
 # {"message":"MLC-LLM server running"}
@@ -100,7 +107,7 @@ curl -X POST https://mlc-llm.fly.dev/v1/chat/completions \
 
 - Add optional Swagger UI (`/docs`) for interactive exploration.
 - Deploy on GPU-backed nodes (AWS EC2/GCP) for realistic speed tests.
-- Support switching models via the `DEFAULT_MODEL` environment variable.
+- Improve configuration options for deploying various models.
 
 ---
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "[INFO] Starting FastAPI server on 0.0.0.0:${PORT:-8000} ..."
-exec mlc_llm serve --host 0.0.0.0 --port "${PORT:-8000}"
+MODEL="${DEFAULT_MODEL:-Llama-2-7b-chat-glm-4b-q0f16_0}"
+echo "[INFO] Starting FastAPI server with model $MODEL on 0.0.0.0:${PORT:-8000} ..."
+exec mlc_llm serve --model "$MODEL" --host 0.0.0.0 --port "${PORT:-8000}"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -271,10 +271,17 @@ To use a different LLM model:
      #!/usr/bin/env bash
      set -euo pipefail
 
-     MODEL="${DEFAULT_MODEL:-Llama-2-7b-chat-glm-4b-q0f16_0}"
-     echo "[INFO] Starting FastAPI server with model $MODEL on 0.0.0.0:${PORT:-8000} ..."
-     exec mlc_llm serve --model "$MODEL" --host 0.0.0.0 --port "${PORT:-8000}"
-     ```
+    MODEL="${DEFAULT_MODEL:-Llama-2-7b-chat-glm-4b-q0f16_0}"
+    echo "[INFO] Starting FastAPI server with model $MODEL on 0.0.0.0:${PORT:-8000} ..."
+    exec mlc_llm serve --model "$MODEL" --host 0.0.0.0 --port "${PORT:-8000}"
+    ```
+
+   The deployed model can be verified by hitting the `/info` endpoint:
+
+   ```bash
+   curl https://<your-app>.fly.dev/info
+   # {"default_model":"Llama-2-13b-chat-v1"}
+   ```
 
 **Considerations**:
 

--- a/python/mlc_llm/server.py
+++ b/python/mlc_llm/server.py
@@ -1,10 +1,21 @@
+import os
 from fastapi import FastAPI, Request
+
+# Default model used by the running server. This can be overridden by setting
+# the ``DEFAULT_MODEL`` environment variable when starting the container.
+DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "Llama-2-7b-chat-glm-4b-q0f16_0")
 
 app = FastAPI()
 
 @app.get("/")
 def read_root():
     return {"message": "MLC-LLM server running"}
+
+
+@app.get("/info")
+def model_info():
+    """Return information about the currently deployed model."""
+    return {"default_model": DEFAULT_MODEL}
 
 @app.post("/v1/chat/completions")
 async def chat(request: Request):

--- a/python/tests/test_server.py
+++ b/python/tests/test_server.py
@@ -22,3 +22,10 @@ def test_chat_endpoint():
     assert body.get("model") == "test"
     assert body["choices"][0]["message"]["role"] == "assistant"
     assert "test model response" in body["choices"][0]["message"]["content"]
+
+
+def test_info_endpoint():
+    response = client.get("/info")
+    assert response.status_code == 200
+    body = response.json()
+    assert "default_model" in body


### PR DESCRIPTION
## Summary
- read `DEFAULT_MODEL` in FastAPI server
- expose `/info` endpoint to show the deployed model
- update entrypoint to pass configurable model
- document how to verify/change models
- test new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68448ec4f1588321bc96dbe66eb5970b