### PR TITLE
Serve WebLLM demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ curl -X POST https://mlc-llm.fly.dev/v1/chat/completions \
 # {"model":"Llama-2-7b-chat-glm-4b-q0f16_0","choices":[{"message":{"role":"assistant","content":"Hello! I am a test model response."}}]}
 ```
 
+A minimal WebLLM front-end is served from the container under `/demo`. Visit
+`https://mlc-llm.fly.dev/demo` to try a browser-based chat interface.
+
 ## Future Work
 
 - Add optional Swagger UI (`/docs`) for interactive exploration.

--- a/frontend/index.css
+++ b/frontend/index.css
@@ -1,0 +1,106 @@
+body,
+html {
+  font-family: Arial, sans-serif;
+  padding: 10px 20px;
+}
+
+.download-container {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+#download-status {
+  border: solid 1px black;
+  box-shadow:
+    0 10px 15px -3px rgba(0, 0, 0, 0.1),
+    0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  padding: 10px;
+}
+
+.chat-container {
+  height: 400px;
+  width: 100%;
+  border: 2px solid black;
+  display: flex;
+  flex-direction: column;
+}
+
+.chat-box {
+  overflow-y: scroll;
+  background-color: #c3c3c3;
+  border: 1px solid #ccc;
+  padding: 5px;
+  flex: 1 1;
+}
+
+.chat-stats {
+  background-color: #d3eceb;
+  flex: 0 0;
+  padding: 10px;
+  font-size: 0.75rem;
+}
+
+.message-container {
+  width: 100%;
+  display: flex;
+}
+
+.message {
+  padding: 10px;
+  margin: 10px 0;
+  border-radius: 10px;
+  width: fit-content;
+}
+
+.message-container.user {
+  justify-content: end;
+}
+
+.message-container.assistant {
+  justify-content: start;
+}
+
+.message-container.user .message {
+  background: #007bff;
+  color: #fff;
+}
+
+.message-container.assistant .message {
+  background: #f1f0f0;
+  color: #333;
+}
+
+.chat-input-container {
+  min-height: 40px;
+  flex: 0 0;
+  display: flex;
+}
+
+#user-input {
+  width: 70%;
+  padding: 10px;
+  border: 1px solid #ccc;
+}
+
+button {
+  width: 25%;
+  padding: 10px;
+  border: none;
+  background-color: #007bff;
+  color: white;
+  cursor: pointer;
+}
+
+button:disabled {
+  background-color: lightgray;
+  cursor: not-allowed;
+}
+
+button:hover:not(:disabled) {
+  background-color: #0056b3;
+}
+
+.hidden {
+  display: none;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Simple Chatbot</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="UTF-8" />
+    <link rel="stylesheet" href="./index.css" />
+  </head>
+
+  <body>
+    <p>Step 1: Initialize WebLLM and Download Model</p>
+    <div class="download-container">
+      <select id="model-selection"></select>
+      <button id="download">Download</button>
+    </div>
+    <p id="download-status" class="hidden"></p>
+
+    <p>Step 2: Chat</p>
+    <div class="chat-container">
+      <div id="chat-box" class="chat-box"></div>
+      <div id="chat-stats" class="chat-stats hidden"></div>
+      <div class="chat-input-container">
+        <input type="text" id="user-input" placeholder="Type a message..." />
+        <button id="send" disabled>Send</button>
+      </div>
+    </div>
+
+    <script src="./index.js" type="module"></script>
+  </body>
+</html>

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,0 +1,150 @@
+import * as webllm from "https://esm.run/@mlc-ai/web-llm";
+
+/*************** WebLLM logic ***************/
+const messages = [
+  {
+    content: "You are a helpful AI agent helping users.",
+    role: "system",
+  },
+];
+
+const availableModels = webllm.prebuiltAppConfig.model_list.map(
+  (m) => m.model_id,
+);
+let selectedModel = "Llama-3.1-8B-Instruct-q4f32_1-1k";
+
+// Callback function for initializing progress
+function updateEngineInitProgressCallback(report) {
+  console.log("initialize", report.progress);
+  document.getElementById("download-status").textContent = report.text;
+}
+
+// Create engine instance
+const engine = new webllm.MLCEngine();
+engine.setInitProgressCallback(updateEngineInitProgressCallback);
+
+async function initializeWebLLMEngine() {
+  document.getElementById("download-status").classList.remove("hidden");
+  selectedModel = document.getElementById("model-selection").value;
+  const config = {
+    temperature: 1.0,
+    top_p: 1,
+  };
+  await engine.reload(selectedModel, config);
+}
+
+async function streamingGenerating(messages, onUpdate, onFinish, onError) {
+  try {
+    let curMessage = "";
+    let usage;
+    const completion = await engine.chat.completions.create({
+      stream: true,
+      messages,
+      stream_options: { include_usage: true },
+    });
+    for await (const chunk of completion) {
+      const curDelta = chunk.choices[0]?.delta.content;
+      if (curDelta) {
+        curMessage += curDelta;
+      }
+      if (chunk.usage) {
+        usage = chunk.usage;
+      }
+      onUpdate(curMessage);
+    }
+    const finalMessage = await engine.getMessage();
+    onFinish(finalMessage, usage);
+  } catch (err) {
+    onError(err);
+  }
+}
+
+/*************** UI logic ***************/
+function onMessageSend() {
+  const input = document.getElementById("user-input").value.trim();
+  const message = {
+    content: input,
+    role: "user",
+  };
+  if (input.length === 0) {
+    return;
+  }
+  document.getElementById("send").disabled = true;
+
+  messages.push(message);
+  appendMessage(message);
+
+  document.getElementById("user-input").value = "";
+  document
+    .getElementById("user-input")
+    .setAttribute("placeholder", "Generating...");
+
+  const aiMessage = {
+    content: "typing...",
+    role: "assistant",
+  };
+  appendMessage(aiMessage);
+
+  const onFinishGenerating = (finalMessage, usage) => {
+    updateLastMessage(finalMessage);
+    document.getElementById("send").disabled = false;
+    const usageText =
+      `prompt_tokens: ${usage.prompt_tokens}, ` +
+      `completion_tokens: ${usage.completion_tokens}, ` +
+      `prefill: ${usage.extra.prefill_tokens_per_s.toFixed(4)} tokens/sec, ` +
+      `decoding: ${usage.extra.decode_tokens_per_s.toFixed(4)} tokens/sec`;
+    document.getElementById("chat-stats").classList.remove("hidden");
+    document.getElementById("chat-stats").textContent = usageText;
+  };
+
+  streamingGenerating(
+    messages,
+    updateLastMessage,
+    onFinishGenerating,
+    console.error,
+  );
+}
+
+function appendMessage(message) {
+  const chatBox = document.getElementById("chat-box");
+  const container = document.createElement("div");
+  container.classList.add("message-container");
+  const newMessage = document.createElement("div");
+  newMessage.classList.add("message");
+  newMessage.textContent = message.content;
+
+  if (message.role === "user") {
+    container.classList.add("user");
+  } else {
+    container.classList.add("assistant");
+  }
+
+  container.appendChild(newMessage);
+  chatBox.appendChild(container);
+  chatBox.scrollTop = chatBox.scrollHeight; // Scroll to the latest message
+}
+
+function updateLastMessage(content) {
+  const messageDoms = document
+    .getElementById("chat-box")
+    .querySelectorAll(".message");
+  const lastMessageDom = messageDoms[messageDoms.length - 1];
+  lastMessageDom.textContent = content;
+}
+
+/*************** UI binding ***************/
+availableModels.forEach((modelId) => {
+  const option = document.createElement("option");
+  option.value = modelId;
+  option.textContent = modelId;
+  document.getElementById("model-selection").appendChild(option);
+});
+document.getElementById("model-selection").value = selectedModel;
+document.getElementById("download").addEventListener("click", function () {
+  initializeWebLLMEngine().then(() => {
+    document.getElementById("send").disabled = false;
+  });
+});
+document.getElementById("send").addEventListener("click", function () {
+  onMessageSend();
+});

--- a/python/mlc_llm/server.py
+++ b/python/mlc_llm/server.py
@@ -1,11 +1,17 @@
 import os
+from pathlib import Path
 from fastapi import FastAPI, Request
+from fastapi.staticfiles import StaticFiles
 
 # Default model used by the running server. This can be overridden by setting
 # the ``DEFAULT_MODEL`` environment variable when starting the container.
 DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "Llama-2-7b-chat-glm-4b-q0f16_0")
 
 app = FastAPI()
+# Serve the simple WebLLM front-end under /demo
+FRONTEND_DIR = Path(__file__).resolve().parent.parent / "frontend"
+if FRONTEND_DIR.exists():
+    app.mount("/demo", StaticFiles(directory=str(FRONTEND_DIR), html=True), name="demo")
 
 @app.get("/")
 def read_root():

--- a/python/tests/test_server.py
+++ b/python/tests/test_server.py
@@ -29,3 +29,9 @@ def test_info_endpoint():
     assert response.status_code == 200
     body = response.json()
     assert "default_model" in body
+
+
+def test_demo_page_served():
+    response = client.get("/demo/")
+    assert response.status_code == 200
+    assert "Simple Chatbot" in response.text


### PR DESCRIPTION
## Summary
- add simple WebLLM chat frontend under `frontend/`
- expose `/demo` route in server to serve static files
- test that demo page is available
- document the new demo URL in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68449398faec832184c407c5f1da9f1c