### PR TITLE
Fix test container entrypoint

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-MODEL="${DEFAULT_MODEL:-Llama-2-7b-chat-glm-4b-q0f16_0}"
-echo "[INFO] Starting FastAPI server with model $MODEL on 0.0.0.0:${PORT:-8000} ..."
-exec mlc_llm serve --model "$MODEL" --host 0.0.0.0 --port "${PORT:-8000}"
+if [[ $# -gt 0 ]]; then
+  # If arguments are provided, execute them instead of starting the server.
+  exec "$@"
+else
+  MODEL="${DEFAULT_MODEL:-Llama-2-7b-chat-glm-4b-q0f16_0}"
+  echo "[INFO] Starting FastAPI server with model $MODEL on 0.0.0.0:${PORT:-8000}..."
+  exec mlc_llm serve --model "$MODEL" --host 0.0.0.0 --port "${PORT:-8000}"
+fi
+

--- a/python/mlc_llm/server.py
+++ b/python/mlc_llm/server.py
@@ -9,7 +9,10 @@ DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "Llama-2-7b-chat-glm-4b-q0f16_0")
 
 app = FastAPI()
 # Serve the simple WebLLM front-end under /demo
-FRONTEND_DIR = Path(__file__).resolve().parent.parent / "frontend"
+# The frontend lives in the repository root under ``frontend/``. When the
+# package is installed in editable mode this directory sits two levels above
+# this file (../../frontend).
+FRONTEND_DIR = Path(__file__).resolve().parents[2] / "frontend"
 if FRONTEND_DIR.exists():
     app.mount("/demo", StaticFiles(directory=str(FRONTEND_DIR), html=True), name="demo")
 


### PR DESCRIPTION
## Summary
- improve entrypoint script so tests run instead of always starting the server
- fix frontend path so demo page is served when package installed

## Testing
- `pytest -q python/tests`

------
https://chatgpt.com/codex/tasks/task_e_68449921ca748321930c4e508e67213f