### PR TITLE
Limit new model to demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ docker build -t mlc-llm-dev -f docker/Dockerfile .
 
 # Start an interactive shell with the repo mounted
 docker run --rm -it -v "$PWD:/workspace" mlc-llm-dev bash
+
+# (inside container) install the package and run tests
+pip install -e python
+pytest python/tests
 ```
 
 ## Live Demo & Sample Output

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -11,7 +11,7 @@ const messages = [
 const availableModels = webllm.prebuiltAppConfig.model_list.map(
   (m) => m.model_id,
 );
-let selectedModel = "Llama-3.1-8B-Instruct-q4f32_1-1k";
+let selectedModel = "Llama-3.2-1B-Instruct-q4f32_1-MLC";
 
 // Callback function for initializing progress
 function updateEngineInitProgressCallback(report) {

--- a/python/mlc_llm/frontend/index.js
+++ b/python/mlc_llm/frontend/index.js
@@ -11,7 +11,7 @@ const messages = [
 const availableModels = webllm.prebuiltAppConfig.model_list.map(
   (m) => m.model_id,
 );
-let selectedModel = "Llama-3.1-8B-Instruct-q4f32_1-1k";
+let selectedModel = "Llama-3.2-1B-Instruct-q4f32_1-MLC";
 
 // Callback function for initializing progress
 function updateEngineInitProgressCallback(report) {


### PR DESCRIPTION
## Summary
- revert default model changes in server, docs, and tests
- keep `Llama-3.2-1B-Instruct-q4f32_1-MLC` as the frontend demo's default
- document installing the package before running local tests

## Testing
- `pip install -e python`
- `scripts/test-image.sh`


------
https://chatgpt.com/codex/tasks/task_e_6844a6051fa8832198c4a2839584b1a3