### PR TITLE
Fix packaging of demo frontend

### DIFF
--- a/python/mlc_llm/frontend/__init__.py
+++ b/python/mlc_llm/frontend/__init__.py
@@ -1,0 +1,1 @@
+# Frontend resources for the demo

--- a/python/setup.py
+++ b/python/setup.py
@@ -5,7 +5,7 @@ setup(
     name="mlc-llm",
     version="0.1.0",
     description="Python package for MLC LLM runtime",
-    packages=find_packages(),
+    packages=find_packages(include=["mlc_llm", "mlc_llm.*"]),
     package_data={"mlc_llm": ["frontend/*"]},
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
## Summary
- mark `mlc_llm.frontend` as a real Python package
- include subpackages when installing the package

This ensures the demo frontend files are installed with the wheel so `/demo` and `/info` endpoints work when the Docker image is rebuilt.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844cea6c6e8832195c066197a31a609