### PR TITLE
Set phi-3-mini model as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ pytest python/tests
 
 The CI/CD pipeline deploys the Docker image to **Fly.io**. A **demo** server is
 running at <https://mlc-llm.fly.dev/> using the quantized model
-`Llama-2-7b-chat-glm-4b-q0f16_0`.
+`phi-3-mini-4k-instruct-q4f16_1`.
 
 > **Note**
 > This server is intended purely for demonstration. It runs with CPU only
@@ -91,7 +91,7 @@ The currently deployed model can be verified by querying the `/info` endpoint:
 
 ```bash
 curl https://mlc-llm.fly.dev/info
-# {"default_model":"Llama-2-7b-chat-glm-4b-q0f16_0"}
+# {"default_model":"phi-3-mini-4k-instruct-q4f16_1"}
 ```
 
 ```bash
@@ -101,12 +101,12 @@ curl https://mlc-llm.fly.dev/
 curl -X POST https://mlc-llm.fly.dev/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-        "model": "Llama-2-7b-chat-glm-4b-q0f16_0",
+        "model": "phi-3-mini-4k-instruct-q4f16_1",
         "messages": [
           {"role": "user", "content": "Hello, who are you?"}
         ]
       }'
-# {"model":"Llama-2-7b-chat-glm-4b-q0f16_0","choices":[{"message":{"role":"assistant","content":"Hello! I am a test model response."}}]}
+# {"model":"phi-3-mini-4k-instruct-q4f16_1","choices":[{"message":{"role":"assistant","content":"Hello! I am a test model response."}}]}
 ```
 
 A minimal WebLLM front-end is served from the container under `/demo`. Visit

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,7 +5,7 @@ if [[ $# -gt 0 ]]; then
   # If arguments are provided, execute them instead of starting the server.
   exec "$@"
 else
-  MODEL="${DEFAULT_MODEL:-Llama-2-7b-chat-glm-4b-q0f16_0}"
+  MODEL="${DEFAULT_MODEL:-phi-3-mini-4k-instruct-q4f16_1}"
   echo "[INFO] Starting FastAPI server with model $MODEL on 0.0.0.0:${PORT:-8000}..."
   exec mlc_llm serve --model "$MODEL" --host 0.0.0.0 --port "${PORT:-8000}"
 fi

--- a/docs/README.md
+++ b/docs/README.md
@@ -132,12 +132,12 @@ curl https://mlc-llm.fly.dev/
 curl -X POST https://mlc-llm.fly.dev/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-        "model": "Llama-2-7b-chat-glm-4b-q0f16_0",
+        "model": "phi-3-mini-4k-instruct-q4f16_1",
         "messages": [
           { "role": "user", "content": "Hello, who are you?" }
         ]
       }'
-# {"model":"Llama-2-7b-chat-glm-4b-q0f16_0","choices":[{"message":{"role":"assistant","content":"Hello! I am a test model response."}}]}
+# {"model":"phi-3-mini-4k-instruct-q4f16_1","choices":[{"message":{"role":"assistant","content":"Hello! I am a test model response."}}]}
 ```
 
 ---

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -118,7 +118,7 @@ Typical workflow inside the container:
 1. **Download Model**:
 
    ```bash
-   mlc_llm download-model --model-name Llama-2-7b-chat-glm-4b-q0f16_0
+   mlc_llm download-model --model-name phi-3-mini-4k-instruct-q4f16_1
    ```
 
    Model weights are stored under `~/.cache/mlc_llm/models/`.
@@ -126,7 +126,7 @@ Typical workflow inside the container:
 2. **Serve Model**:
 
    ```bash
-   mlc_llm serve --model Llama-2-7b-chat-glm-4b-q0f16_0 --device cpu --host 0.0.0.0 --port 8000
+   mlc_llm serve --model phi-3-mini-4k-instruct-q4f16_1 --device cpu --host 0.0.0.0 --port 8000
    ```
 
    This spins up a Uvicorn server exposing REST endpoints.
@@ -196,10 +196,10 @@ exec mlc_llm serve --host 0.0.0.0 --port "${PORT:-8000}"
    curl -X POST http://localhost:8000/v1/chat/completions \
      -H "Content-Type: application/json" \
      -d '{
-           "model":"Llama-2-7b-chat-glm-4b-q0f16_0",
+          "model":"phi-3-mini-4k-instruct-q4f16_1",
            "messages":[{"role":"user","content":"Hello"}]
          }'
-   # → {"model":"Llama-2-7b-chat-glm-4b-q0f16_0","choices":[{"message":{"role":"assistant","content":"Hello! I am a test model response."}}]}
+   # → {"model":"phi-3-mini-4k-instruct-q4f16_1","choices":[{"message":{"role":"assistant","content":"Hello! I am a test model response."}}]}
    ```
 
 ### 4.2 CI/CD Automated Test
@@ -274,7 +274,7 @@ To use a different LLM model:
      #!/usr/bin/env bash
      set -euo pipefail
 
-    MODEL="${DEFAULT_MODEL:-Llama-2-7b-chat-glm-4b-q0f16_0}"
+   MODEL="${DEFAULT_MODEL:-phi-3-mini-4k-instruct-q4f16_1}"
     echo "[INFO] Starting FastAPI server with model $MODEL on 0.0.0.0:${PORT:-8000} ..."
     exec mlc_llm serve --model "$MODEL" --host 0.0.0.0 --port "${PORT:-8000}"
     ```
@@ -520,7 +520,7 @@ curl http://localhost:8000/
 curl -X POST http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-        "model":"Llama-2-7b-chat-glm-4b-q0f16_0",
+        "model":"phi-3-mini-4k-instruct-q4f16_1",
         "messages":[{"role":"user","content":"Hello"}]
       }'
 ```
@@ -529,7 +529,7 @@ curl -X POST http://localhost:8000/v1/chat/completions \
 
 ```json
 {
-  "model":"Llama-2-7b-chat-glm-4b-q0f16_0",
+  "model":"phi-3-mini-4k-instruct-q4f16_1",
   "choices":[
     {
       "message":{
@@ -658,7 +658,7 @@ INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
    curl -X POST https://mlc-llm.fly.dev/v1/chat/completions \
      -H "Content-Type: application/json" \
      -d '{
-           "model":"Llama-2-7b-chat-glm-4b-q0f16_0",
+          "model":"phi-3-mini-4k-instruct-q4f16_1",
            "messages":[{"role":"user","content":"Hello"}]
          }'
    ```
@@ -789,12 +789,12 @@ The official docs at **[https://llm.mlc.ai/](https://llm.mlc.ai/)** provide up-t
   * Download a model:
 
     ```bash
-    mlc_llm download-model --model-name Llama-2-7b-chat-glm-4b-q0f16_0
+    mlc_llm download-model --model-name phi-3-mini-4k-instruct-q4f16_1
     ```
   * Serve a model:
 
     ```bash
-    mlc_llm serve --model Llama-2-7b-chat-glm-4b-q0f16_0 --device cpu --host 0.0.0.0 --port 8000
+    mlc_llm serve --model phi-3-mini-4k-instruct-q4f16_1 --device cpu --host 0.0.0.0 --port 8000
     ```
   * Python client example:
 
@@ -804,7 +804,7 @@ The official docs at **[https://llm.mlc.ai/](https://llm.mlc.ai/)** provide up-t
     async def main():
         client = AsyncClient("http://localhost:8000")
         resp = await client.chat_completions(
-            "Llama-2-7b-chat-glm-4b-q0f16_0",
+            "phi-3-mini-4k-instruct-q4f16_1",
             [{"role":"user","content":"Hello"}]
         )
         print(resp.choices[0].message.content)
@@ -818,7 +818,7 @@ The official docs at **[https://llm.mlc.ai/](https://llm.mlc.ai/)** provide up-t
   [https://llm.mlc.ai/docs/models/](https://llm.mlc.ai/docs/models/)
 * **Usage**:
   Provides a list of supported model names (e.g.,
-  `"Llama-2-7b-chat-glm-4b-q0f16_0"`, `"Llama-2-13b-chat-v1"`).
+  `"phi-3-mini-4k-instruct-q4f16_1"`, `"Llama-2-13b-chat-v1"`).
 * When deploying, ensure you reference a valid model string.
 
 ### 13.4 CLI Commands

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -11,7 +11,7 @@ const messages = [
 const availableModels = webllm.prebuiltAppConfig.model_list.map(
   (m) => m.model_id,
 );
-let selectedModel = "Llama-3.2-1B-Instruct-q4f32_1-MLC";
+let selectedModel = "phi-3-mini-4k-instruct-q4f16_1";
 
 // Callback function for initializing progress
 function updateEngineInitProgressCallback(report) {

--- a/python/mlc_llm/frontend/index.js
+++ b/python/mlc_llm/frontend/index.js
@@ -11,7 +11,7 @@ const messages = [
 const availableModels = webllm.prebuiltAppConfig.model_list.map(
   (m) => m.model_id,
 );
-let selectedModel = "Llama-3.2-1B-Instruct-q4f32_1-MLC";
+let selectedModel = "phi-3-mini-4k-instruct-q4f16_1";
 
 // Callback function for initializing progress
 function updateEngineInitProgressCallback(report) {

--- a/python/mlc_llm/server.py
+++ b/python/mlc_llm/server.py
@@ -5,8 +5,8 @@ from fastapi.staticfiles import StaticFiles
 
 # Default model used by the running server. This can be overridden by setting
 # the ``DEFAULT_MODEL`` environment variable when starting the container.
-# DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "Llama-2-7b-chat-glm-4b-q0f16_0",)
-DEFAULT_MODEL = "HF://mlc-ai/Phi-3.5-vision-instruct-q4f16_1-MLC"
+# DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "phi-3-mini-4k-instruct-q4f16_1")
+DEFAULT_MODEL = "HF://mlc-ai/phi-3-mini-4k-instruct-q4f16_1"
 
 app = FastAPI()
 # Serve the simple WebLLM front-end under /demo

--- a/scripts/test-image.sh
+++ b/scripts/test-image.sh
@@ -55,7 +55,7 @@ echo "[INFO] Running API test (POST /v1/chat/completions)..."
 set +e
 HTTP_CODE=$(curl -s -X POST http://localhost:8000/v1/chat/completions \
         -H "Content-Type: application/json" \
-        -d '{"model":"Llama-2-7b-chat-glm-4b-q0f16_0","messages":[{"role":"user","content":"Hello?"}]}' \
+        -d '{"model":"phi-3-mini-4k-instruct-q4f16_1","messages":[{"role":"user","content":"Hello?"}]}' \
         -o /tmp/chat_response.json \
         -w "%{http_code}")
 TEST_EXIT=$?


### PR DESCRIPTION
## Summary
- default model is `phi-3-mini-4k-instruct-q4f16_1`
- update documentation and sample commands to use the new model
- change Docker entrypoint and test script to reference the model
- adjust frontend defaults

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849cd8376748321931a28357b6c012d